### PR TITLE
DE translation 'new branch' in array.xml

### DIFF
--- a/res/values-de/arrays.xml
+++ b/res/values-de/arrays.xml
@@ -12,6 +12,7 @@
         <item>Löschen</item>
     </string-array>
     <string-array name="repo_operation_names">
+        <item>Neuer Branch</item>
         <item>Pull</item>
         <item>Push</item>
         <item>Alles zum Staging-Bereich hinzufügen</item>


### PR DESCRIPTION
Added german translation for "new branch". Without this item, the german translation does not work properly. I would suggest to check the other translations, too.
